### PR TITLE
Add indexes for entryable lookups

### DIFF
--- a/db/migrate/20250528190000_add_entryable_indexes_to_entries.rb
+++ b/db/migrate/20250528190000_add_entryable_indexes_to_entries.rb
@@ -1,0 +1,8 @@
+class AddEntryableIndexesToEntries < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :entries, [:entryable_type, :entryable_id], algorithm: :concurrently
+    add_index :entries, [:entryable_type, :entryable_id, :date], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_23_131455) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_28_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -30,7 +30,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_23_131455) do
     t.decimal "balance", precision: 19, scale: 4
     t.string "currency"
     t.boolean "is_active", default: true, null: false
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Loan'::character varying, 'CreditCard'::character varying, 'OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Loan'::character varying)::text, ('CreditCard'::character varying)::text, ('OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
     t.uuid "import_id"
     t.uuid "plaid_account_id"
     t.boolean "scheduled_for_deletion", default: false
@@ -200,6 +200,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_23_131455) do
     t.string "plaid_id"
     t.jsonb "locked_attributes", default: {}
     t.index ["account_id"], name: "index_entries_on_account_id"
+    t.index ["entryable_type", "entryable_id", "date"], name: "index_entries_on_entryable_type_and_entryable_id_and_date"
+    t.index ["entryable_type", "entryable_id"], name: "index_entries_on_entryable_type_and_entryable_id"
     t.index ["import_id"], name: "index_entries_on_import_id"
   end
 

--- a/lib/tasks/diagnostics.rake
+++ b/lib/tasks/diagnostics.rake
@@ -1,0 +1,19 @@
+namespace :diagnostics do
+  desc "Print EXPLAIN output for TransactionsController#index query"
+  task transactions_query_plan: :environment do
+    family  = Family.first || Family.create!(name: "Demo")
+    account = Account.first || family.accounts.create!(name: "Demo", balance: 0, currency: "USD", accountable: Depository.new)
+    start_date = Date.current - 30
+
+    ActiveRecord::Base.connection.execute("SET enable_seqscan = off")
+    ActiveRecord::Base.connection.execute("SET enable_indexscan = on")
+
+    join_sql = "JOIN transactions ON entries.entryable_id = transactions.id AND entries.entryable_type = 'Transaction'"
+    query = Entry
+              .joins(join_sql)
+              .where("entries.date >= ?", start_date)
+              .order(date: :desc)
+
+    puts query.explain.inspect
+  end
+end

--- a/test/models/entry_indexes_test.rb
+++ b/test/models/entry_indexes_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class EntryIndexesTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+
+  test "transactions query uses entryable index" do
+    account = accounts(:depository)
+    create_transaction(account: account, date: Date.current)
+
+    ActiveRecord::Base.connection.execute("SET enable_seqscan = off")
+
+    query = Entry
+              .joins("JOIN transactions ON entries.entryable_id = transactions.id")
+              .where(entryable_type: "Transaction", account_id: account.id)
+              .where("entries.date >= ?", Date.current - 5)
+              .order(date: :desc)
+              .limit(1)
+
+    plan = query.explain.inspect
+
+    assert_includes plan, "index_entries_on_entryable_type_and_entryable_id"
+  end
+end


### PR DESCRIPTION
## Summary
- add indexes for Entry#entryable lookup
- add diagnostic rake task for query plan
- ensure test forces index usage

## Testing
- `bundle exec rake test TEST=test/models/entry_indexes_test.rb`